### PR TITLE
Add setters for units and content on game structure

### DIFF
--- a/backend/src/game.rs
+++ b/backend/src/game.rs
@@ -20,8 +20,8 @@ impl Game {
         }
     }
 
-    pub fn set_unit(&mut self, x: u32, y: u32, unit: Unit) -> Result<(), &str> {
-        match self.field.get_hex(x, y) {
+    pub fn set_unit(&mut self, y: u32, x: u32, unit: Unit) -> Result<(), &str> {
+        match self.field.get_hex(y, x) {
             Some(hex) => {
                 hex.unit = Some(unit);
                 Ok(())
@@ -30,8 +30,8 @@ impl Game {
         }
     }
 
-    pub fn set_content(&mut self, x: u32, y: u32, content: Content) -> Result<(), &str> {
-        match self.field.get_hex(x, y) {
+    pub fn set_content(&mut self, y: u32, x: u32, content: Content) -> Result<(), &str> {
+        match self.field.get_hex(y, x) {
             Some(hex) => {
                 hex.content = Some(content);
                 Ok(())
@@ -80,18 +80,18 @@ mod test {
             speed,
         };
 
-        let res = game.set_unit(x1, y1, unit.clone());
+        let res = game.set_unit(y1, x1, unit.clone());
         assert!(res.is_ok());
-        assert!(game.field.get_hex(x1, y1).unwrap().unit.is_some());
-        assert!(game.field.get_hex(x1, y1).unwrap().content.is_none());
+        assert!(game.field.get_hex(y1, x1).unwrap().unit.is_some());
+        assert!(game.field.get_hex(y1, x1).unwrap().content.is_none());
 
-        let field_unit = game.field.get_hex(x1, y1).unwrap().unit.as_ref().unwrap();
+        let field_unit = game.field.get_hex(y1, x1).unwrap().unit.as_ref().unwrap();
         assert_eq!(field_unit.player, player);
         assert_eq!(field_unit.hp, hp);
         assert_eq!(field_unit.attack, attack);
         assert_eq!(field_unit.speed, speed);
 
-        let res = game.set_unit(x2, y2, unit);
+        let res = game.set_unit(y2, x2, unit);
         assert!(res.is_err());
         assert_eq!(res.unwrap_err(), "no hex");
     }
@@ -108,12 +108,12 @@ mod test {
         let mut game = Game::new(5, 5);
         let wall = Wall {};
 
-        let res = game.set_content(x1, y1, Content::Wall(wall.clone()));
+        let res = game.set_content(y1, x1, Content::Wall(wall.clone()));
         assert!(res.is_ok());
-        assert!(game.field.get_hex(x1, y1).unwrap().unit.is_none());
-        assert!(game.field.get_hex(x1, y1).unwrap().content.is_some());
+        assert!(game.field.get_hex(y1, x1).unwrap().unit.is_none());
+        assert!(game.field.get_hex(y1, x1).unwrap().content.is_some());
 
-        let res = game.set_content(x2, y2, Content::Wall(wall));
+        let res = game.set_content(y2, x2, Content::Wall(wall));
         assert!(res.is_err());
         assert_eq!(res.unwrap_err(), "no hex");
     }

--- a/backend/src/game.rs
+++ b/backend/src/game.rs
@@ -44,7 +44,7 @@ impl Game {
 #[cfg(test)]
 mod test {
     use super::super::game_objects::hex_objects::content::Content;
-    use super::super::game_objects::hex_objects::wall::{Wall, WallKind};
+    use super::super::game_objects::hex_objects::wall::Wall;
     use super::super::game_objects::unit::Unit;
     use super::Game;
 
@@ -106,9 +106,7 @@ mod test {
         let y2 = 18;
 
         let mut game = Game::new(5, 5);
-        let wall = Wall {
-            kind: WallKind::Default,
-        };
+        let wall = Wall {};
 
         let res = game.set_content(x1, y1, Content::Wall(wall.clone()));
         assert!(res.is_ok());

--- a/backend/src/game.rs
+++ b/backend/src/game.rs
@@ -1,4 +1,7 @@
 use super::game_objects::grid::Grid;
+use super::game_objects::hex_objects::content::Content;
+use super::game_objects::unit::Unit;
+
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -16,10 +19,33 @@ impl Game {
             field: Grid::new(row_n, col_n),
         }
     }
+
+    pub fn set_unit(&mut self, x: u32, y: u32, unit: Unit) -> Result<(), &str> {
+        match self.field.get_hex(x, y) {
+            Some(hex) => {
+                hex.unit = Some(unit);
+                Ok(())
+            }
+            None => Err("no hex"),
+        }
+    }
+
+    pub fn set_content(&mut self, x: u32, y: u32, content: Content) -> Result<(), &str> {
+        match self.field.get_hex(x, y) {
+            Some(hex) => {
+                hex.content = Some(content);
+                Ok(())
+            }
+            None => Err("no hex"),
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
+    use super::super::game_objects::hex_objects::content::Content;
+    use super::super::game_objects::hex_objects::wall::{Wall, WallKind};
+    use super::super::game_objects::unit::Unit;
     use super::Game;
 
     #[test]
@@ -31,6 +57,69 @@ mod test {
         assert_eq!(game.row_n, row_n);
         assert_eq!(game.col_n, col_n);
     }
+
+    #[test]
+    fn set_unit() {
+        // coords of existing hex
+        let x1 = 0;
+        let y1 = 1;
+        // coords of non existing hex
+        let x2 = 10;
+        let y2 = 18;
+        // unit
+        let player = 1;
+        let hp = 1;
+        let attack = [1, 2];
+        let speed = 1;
+
+        let mut game = Game::new(5, 5);
+        let unit = Unit {
+            player,
+            hp,
+            attack,
+            speed,
+        };
+
+        let res = game.set_unit(x1, y1, unit.clone());
+        assert!(res.is_ok());
+        assert!(game.field.get_hex(x1, y1).unwrap().unit.is_some());
+        assert!(game.field.get_hex(x1, y1).unwrap().content.is_none());
+
+        let field_unit = game.field.get_hex(x1, y1).unwrap().unit.as_ref().unwrap();
+        assert_eq!(field_unit.player, player);
+        assert_eq!(field_unit.hp, hp);
+        assert_eq!(field_unit.attack, attack);
+        assert_eq!(field_unit.speed, speed);
+
+        let res = game.set_unit(x2, y2, unit);
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err(), "no hex");
+    }
+
+    #[test]
+    fn set_content() {
+        // coords of existing hex
+        let x1 = 0;
+        let y1 = 1;
+        // coords of non existing hex
+        let x2 = 10;
+        let y2 = 18;
+
+        let mut game = Game::new(5, 5);
+        let wall = Wall {
+            kind: WallKind::Default,
+        };
+
+        let res = game.set_content(x1, y1, Content::Wall(wall.clone()));
+        assert!(res.is_ok());
+        assert!(game.field.get_hex(x1, y1).unwrap().unit.is_none());
+        assert!(game.field.get_hex(x1, y1).unwrap().content.is_some());
+
+        let res = game.set_content(x2, y2, Content::Wall(wall));
+        assert!(res.is_err());
+        assert_eq!(res.unwrap_err(), "no hex");
+    }
+
     #[test]
     fn serialize() {
         let row_n = 1;

--- a/backend/src/game_objects/grid.rs
+++ b/backend/src/game_objects/grid.rs
@@ -21,6 +21,10 @@ impl Grid {
 
         Grid { hexes }
     }
+
+    pub fn get_hex(&mut self, x: u32, y: u32) -> Option<&mut Hex> {
+        self.hexes.iter_mut().find(|hex| hex.x == x && hex.y == y)
+    }
 }
 
 #[cfg(test)]
@@ -50,6 +54,23 @@ mod test {
                 assert_eq!(hex.content.is_none(), true);
             }
         }
+    }
+
+    #[test]
+    fn get_hex() {
+        let mut grid = Grid::new(5, 5);
+
+        // hex that exists
+        let hex = grid.get_hex(1, 2);
+
+        assert!(hex.is_some());
+        let hex = hex.unwrap();
+        assert_eq!(hex.x, 1);
+        assert_eq!(hex.y, 2);
+
+        // hex that does not exists
+        let hex = grid.get_hex(3, 8);
+        assert!(hex.is_none());
     }
 
     #[test]

--- a/backend/src/game_objects/grid.rs
+++ b/backend/src/game_objects/grid.rs
@@ -22,7 +22,7 @@ impl Grid {
         Grid { hexes }
     }
 
-    pub fn get_hex(&mut self, x: u32, y: u32) -> Option<&mut Hex> {
+    pub fn get_hex(&mut self, y: u32, x: u32) -> Option<&mut Hex> {
         self.hexes.iter_mut().find(|hex| hex.x == x && hex.y == y)
     }
 }
@@ -65,8 +65,8 @@ mod test {
 
         assert!(hex.is_some());
         let hex = hex.unwrap();
-        assert_eq!(hex.x, 1);
-        assert_eq!(hex.y, 2);
+        assert_eq!(hex.y, 1);
+        assert_eq!(hex.x, 2);
 
         // hex that does not exists
         let hex = grid.get_hex(3, 8);

--- a/backend/src/game_objects/grid.rs
+++ b/backend/src/game_objects/grid.rs
@@ -31,7 +31,7 @@ impl Grid {
 mod test {
     use super::super::hex::Hex;
     use super::super::hex_objects::content::Content;
-    use super::super::hex_objects::wall::{Wall, WallKind};
+    use super::super::hex_objects::wall::Wall;
     use super::super::unit::Unit;
     use super::Grid;
 
@@ -91,9 +91,7 @@ mod test {
             x: 1,
             y: 2,
             unit: Some(unit),
-            content: Some(Content::Wall(Wall {
-                kind: WallKind::Default,
-            })),
+            content: Some(Content::Wall(Wall {})),
         };
         let grid = Grid {
             hexes: vec![hex_one.clone(), hex_two.clone()],

--- a/backend/src/game_objects/hex.rs
+++ b/backend/src/game_objects/hex.rs
@@ -6,14 +6,16 @@ use serde::Serialize;
 pub struct Hex {
     pub x: u32,
     pub y: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub unit: Option<Unit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<Content>,
 }
 
 #[cfg(test)]
 mod test {
     use super::super::hex_objects::content::Content;
-    use super::super::hex_objects::wall::{Wall, WallKind};
+    use super::super::hex_objects::wall::Wall;
     use super::super::unit::Unit;
     use super::Hex;
 
@@ -27,10 +29,7 @@ mod test {
         };
         let cell_string = serde_json::to_string(&cell).unwrap();
 
-        assert_eq!(
-            cell_string,
-            "{\"x\":1,\"y\":2,\"unit\":null,\"content\":null}",
-        );
+        assert_eq!(cell_string, "{\"x\":1,\"y\":2}",);
     }
 
     #[test]
@@ -41,24 +40,22 @@ mod test {
             attack: [2, 4],
             speed: 4,
         };
-        let wall = Wall {
-            kind: WallKind::Default,
-        };
+        let content = Content::Wall(Wall {});
         let hex = Hex {
             x: 1,
             y: 2,
             unit: Some(unit.clone()),
-            content: Some(Content::Wall(wall.clone())),
+            content: Some(content.clone()),
         };
         let hex_string = serde_json::to_string(&hex).unwrap();
         let unit_string = serde_json::to_string(&unit).unwrap();
-        let wall_string = serde_json::to_string(&wall).unwrap();
+        let content_string = serde_json::to_string(&content).unwrap();
 
         assert_eq!(
             hex_string,
             format!(
-                "{{\"x\":1,\"y\":2,\"unit\":{},\"content\":{{\"Wall\":{}}}}}",
-                unit_string, wall_string,
+                "{{\"x\":1,\"y\":2,\"unit\":{},\"content\":{}}}",
+                unit_string, content_string,
             ),
         );
     }

--- a/backend/src/game_objects/hex_objects/content.rs
+++ b/backend/src/game_objects/hex_objects/content.rs
@@ -2,6 +2,23 @@ use super::wall::Wall;
 use serde::Serialize;
 
 #[derive(Clone, Serialize)]
+#[serde(tag = "type")]
 pub enum Content {
+    #[serde(rename = "wall")]
     Wall(Wall),
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::wall::Wall;
+    use super::Content;
+
+    #[test]
+    fn serialize() {
+        let wall = Wall {};
+        let content = Content::Wall(wall);
+
+        let content_string = serde_json::to_string(&content).unwrap();
+        assert_eq!(content_string, "{\"type\":\"wall\"}");
+    }
 }

--- a/backend/src/game_objects/hex_objects/wall.rs
+++ b/backend/src/game_objects/hex_objects/wall.rs
@@ -1,26 +1,4 @@
 use serde::Serialize;
 
 #[derive(Clone, Serialize)]
-pub enum WallKind {
-    Default,
-}
-
-#[derive(Clone, Serialize)]
-pub struct Wall {
-    pub kind: WallKind,
-}
-
-#[cfg(test)]
-mod test {
-    use super::{Wall, WallKind};
-
-    #[test]
-    fn serialize() {
-        let wall = Wall {
-            kind: WallKind::Default,
-        };
-        let wall_string = serde_json::to_string(&wall).unwrap();
-
-        assert_eq!(wall_string, "{\"kind\":\"Default\"}");
-    }
-}
+pub struct Wall {}

--- a/backend/src/websocket.rs
+++ b/backend/src/websocket.rs
@@ -3,7 +3,7 @@ use actix_web_actors::ws;
 
 use super::game::Game;
 use super::game_objects::hex_objects::content::Content;
-use super::game_objects::hex_objects::wall::{Wall, WallKind};
+use super::game_objects::hex_objects::wall::Wall;
 use super::game_objects::unit::Unit;
 
 /// Define http actor
@@ -37,9 +37,7 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for Websocket {
             attack: [1, 2],
             speed: 1,
         };
-        let wall = Wall {
-            kind: WallKind::Default,
-        };
+        let wall = Wall {};
 
         match game.set_unit(0, 0, unit) {
             Ok(_) => {}

--- a/backend/src/websocket.rs
+++ b/backend/src/websocket.rs
@@ -2,6 +2,9 @@ use actix::{Actor, StreamHandler};
 use actix_web_actors::ws;
 
 use super::game::Game;
+use super::game_objects::hex_objects::content::Content;
+use super::game_objects::hex_objects::wall::{Wall, WallKind};
+use super::game_objects::unit::Unit;
 
 /// Define http actor
 pub struct Websocket;
@@ -27,7 +30,27 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for Websocket {
     fn started(&mut self, ctx: &mut Self::Context) {
         debug!("Client connected");
 
-        let game = Game::new(2, 2);
+        let mut game = Game::new(2, 2);
+        let unit = Unit {
+            player: 1,
+            hp: 1,
+            attack: [1, 2],
+            speed: 1,
+        };
+        let wall = Wall {
+            kind: WallKind::Default,
+        };
+
+        match game.set_unit(0, 0, unit) {
+            Ok(_) => {}
+            Err(error) => ctx.text(error),
+        }
+
+        match game.set_content(1, 1, Content::Wall(wall)) {
+            Ok(_) => {}
+            Err(error) => ctx.text(error),
+        }
+
         // TODO: process error on unwrap
         ctx.text(&serde_json::to_string(&game).unwrap());
     }


### PR DESCRIPTION
#38 

Now on connect you'll receive field with one unit and one wall on it!
Serialization improves:
- Option fields now do not serialize
- All keys and values are lowercased
- Redundant type of walls dismissed
