### PR TITLE
Update package versions for no reason

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,17 +7,17 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix = "0.9.0"
+actix = "0.10"
 actix-rt = "1.0"
-actix-web = "2.0"
-actix-web-actors = "2.0"
+actix-web = "3.1"
+actix-web-actors = "3.0"
 argon2rs = "0.2.5"
 chrono = { version = "0.4", features = ["serde"] }
 log = "0.4"
 serde_json = "1.0"
 serde = "1.0"
 lazy_static = "1.4.0"
-uuid = { version = "0.7", features = ["serde", "v4"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 rand = "0.7"
 eyre = "0.6"
 color-eyre = "0.5"


### PR DESCRIPTION
I found [cargo outdated](https://github.com/kbknapp/cargo-outdated ) unit and update our dependency a little