### PR TITLE
Add movement points to units

### DIFF
--- a/backend/src/api/response.rs
+++ b/backend/src/api/response.rs
@@ -11,6 +11,9 @@ const CMD_DESELECT: &str = "deselecting";
 const CMD_MOVE: &str = "moving";
 const CMD_ATTACK: &str = "attacking";
 const CMD_ERROR: &str = "error";
+const CMD_HURT: &str = "hurt";
+const CMD_DIE: &str = "die";
+const CMD_UPDATE: &str = "update";
 
 #[derive(Serialize)]
 pub struct Field {
@@ -66,38 +69,36 @@ impl Deselecting {
 #[derive(Serialize)]
 pub struct Moving {
     cmd: String,
-    coords: Vec<Point>,
+    coords: Vec<Hex>,
 }
 
 impl Moving {
-    pub fn new(points: Vec<Point>) -> Moving {
+    pub fn new(hexes: Vec<Hex>) -> Moving {
         Moving {
             cmd: CMD_MOVE.to_string(),
-            coords: points,
+            coords: hexes,
         }
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct Attacking {
     cmd: String,
     from: Point,
     to: Point,
-    changes: Changes,
 }
 
 impl Attacking {
-    pub fn new(from: Point, to: Point, hurt: Vec<Hex>, die: Vec<Hex>) -> Attacking {
+    pub fn new(from: Point, to: Point) -> Attacking {
         Attacking {
             cmd: CMD_ATTACK.to_string(),
             from,
             to,
-            changes: Changes { hurt, die },
         }
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 pub struct State {
     cmd: String,
     state: String,
@@ -128,7 +129,46 @@ impl Error {
 }
 
 #[derive(Serialize, Debug)]
-pub struct Changes {
-    hurt: Vec<Hex>,
-    die: Vec<Hex>,
+pub struct Hurt {
+    cmd: String,
+    hexes: Vec<Hex>,
+}
+
+impl Hurt {
+    pub fn new(hexes: Vec<Hex>) -> Hurt {
+        Hurt {
+            cmd: CMD_HURT.to_string(),
+            hexes,
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct Die {
+    cmd: String,
+    hexes: Vec<Hex>,
+}
+
+impl Die {
+    pub fn new(hexes: Vec<Hex>) -> Die {
+        Die {
+            cmd: CMD_DIE.to_string(),
+            hexes,
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct Update {
+    cmd: String,
+    hexes: Vec<Hex>,
+}
+
+impl Update {
+    pub fn new(hexes: Vec<Hex>) -> Update {
+        Update {
+            cmd: CMD_UPDATE.to_string(),
+            hexes,
+        }
+    }
 }

--- a/backend/src/game_objects/grid.rs
+++ b/backend/src/game_objects/grid.rs
@@ -84,12 +84,7 @@ mod test {
 
     #[test]
     fn serialize() {
-        let unit = Unit {
-            player: 1,
-            hp: 1,
-            damage: [120, 130],
-            speed: 1,
-        };
+        let unit = Unit::new(1, 1, [120, 130], 1);
         let hex_one = Hex {
             x: 1,
             y: 1,

--- a/backend/src/game_objects/hex.rs
+++ b/backend/src/game_objects/hex.rs
@@ -60,12 +60,7 @@ mod test {
 
     #[test]
     fn serialize_with_unit_and_content_wall() {
-        let unit = Unit {
-            player: 1,
-            hp: 10,
-            damage: [2, 4],
-            speed: 4,
-        };
+        let unit = Unit::new(1, 10, [2, 4], 4);
         let content = Content::Wall(Wall {});
         let hex = Hex {
             x: 1,

--- a/backend/src/game_objects/unit.rs
+++ b/backend/src/game_objects/unit.rs
@@ -1,37 +1,45 @@
 use serde::Serialize;
 
-#[derive(Clone, Serialize, Debug)]
+#[derive(Clone, Serialize, Debug, Copy)]
 pub struct Unit {
     pub player: u32,
     pub hp: u32,
     pub damage: [u32; 2],
     pub speed: u32,
+    pub movements: u32,
 }
 
 impl Unit {
+    pub fn new(player: u32, hp: u32, damage: [u32; 2], speed: u32) -> Unit {
+        assert!(damage[0] <= damage[1]);
+        Unit {
+            player,
+            hp,
+            damage,
+            speed,
+            movements: speed,
+        }
+    }
+
     pub fn change_hp(&mut self, diff: i32) {
         let hp = (self.hp as i32) + diff;
         self.hp = if hp >= 0 { hp as u32 } else { 0 };
     }
+
+    pub fn change_movements(&mut self, diff: u32) {
+        assert!(self.movements >= diff);
+
+        self.movements -= diff;
+    }
+
+    pub fn restore_movements(&mut self) {
+        self.movements = self.speed;
+    }
+
+    pub fn has_moved(self) -> bool {
+        self.movements != self.speed
+    }
 }
 
 #[cfg(test)]
-mod test {
-    use super::Unit;
-
-    #[test]
-    fn serialize() {
-        let unit = Unit {
-            player: 1,
-            hp: 10,
-            damage: [2, 3],
-            speed: 3,
-        };
-        let unit_string = serde_json::to_string(&unit).unwrap();
-
-        assert_eq!(
-            unit_string,
-            "{\"player\":1,\"hp\":10,\"damage\":[2,3],\"speed\":3}",
-        );
-    }
-}
+mod test {}


### PR DESCRIPTION
Reduse them on turn and refresh after move
Also they updates on UI after move, but not after turn

API for move slightly changed: now it is array of hexes, not points
This is because we need change speed of unit on UI, so i send whole path to frontend

Seems overkilling and this does not solve problem with unit's refreshing in the new turn begining